### PR TITLE
Fix screenshot url

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ the same purpose as the variables `prefix-arg` and `current-prefix-arg` do
 for any command that was called after the prefix arguments have been
 set using a command such as `universal-argument`.
 
-![screenshot](http://readme.emacsair.me/assets/readme/transient.png)
+![screenshot](https://emacsair.me/assets/posts/transient.png)


### PR DESCRIPTION
The screenshot seems to have been moved to: 
https://emacsair.me/assets/posts/transient.png

At least that's the url for the first screenshot on: 
https://emacsair.me/2019/02/14/transient-0.1/