### PR TITLE
Try infer `argument-regexp` from `choices` and `argument-format`.

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -514,9 +514,10 @@ slot is non-nil."
 
 (cl-defmethod initialize-instance ((obj transient-switches) slots)
   (cl-call-next-method)
-  (-let [(&plist :argument-regexp :choices :argument-format) slots]
+  (cl-destructuring-bind
+      (&key choices argument-format argument-regexp &allow-other-keys) slots
     (unless argument-regexp
-      (setf (oref obj argument-regexp)
+      (oset obj argument-regexp
             (--> choices
                  (regexp-opt it t)
                  (format (regexp-quote argument-format) it)

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -512,6 +512,16 @@ slot is non-nil."
    (argument-regexp  :initarg :argument-regexp))
   "Class used for sets of mutually exclusive command-line switches.")
 
+(cl-defmethod initialize-instance ((obj transient-switches) slots)
+  (cl-call-next-method)
+  (-let [(&plist :argument-regexp :choices :argument-format) slots]
+    (unless argument-regexp
+      (setf (oref obj argument-regexp)
+            (--> choices
+                 (regexp-opt it t)
+                 (format (regexp-quote argument-format) it)
+                 (concat "\\(" it "\\)"))))))
+
 (defclass transient-files (transient-infix) ()
   "Class used for the \"--\" argument.
 All remaining arguments are treated as files.


### PR DESCRIPTION
Guess `argument-regexp` for `transient-switches`.

For `arguement-format` as `"--test-%s"`, `choices` as `'("A" "B" "C")`
Simply use the values in `choices` slot and build regexp like

`"\\(--test-\\(A\\|B\\|C\\)\\)"`

You can specific `arguement-regexp` to override the inference.