### PR TITLE
Add transient-buffer-name variable

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -350,7 +350,7 @@ See info node `(transient)Enabling and Disabling Suffixes'."
 
 (defface transient-disabled-suffix
   '((t :background "red" :foreground "black" :weight bold))
-  "Face used for disables levels while editing suffix levels.
+  "Face used for disabled levels while editing suffix levels.
 See info node `(transient)Enabling and Disabling Suffixes'."
   :group 'transient-faces)
 

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -1019,6 +1019,9 @@ variable instead.")
 
 (defvar transient--stack nil)
 
+(defvar transient--buffer-name " *transient*"
+  "Name of the transient buffer.")
+
 (defvar transient--window nil
   "The window used to display the transient popup.")
 
@@ -2419,7 +2422,7 @@ have a history of their own.")
 (defun transient--show ()
   (transient--timer-cancel)
   (setq transient--showp t)
-  (let ((buf (get-buffer-create " *transient*"))
+  (let ((buf (get-buffer-create transient--buffer-name))
         (focus nil))
     (unless (window-live-p transient--window)
       (setq transient--window


### PR DESCRIPTION
Hello, I would like to rename transient buffer to `*transient*` (without a space), so I hope it is OK to introduce this variable.

Also I fixed a small typo in this commit, or should I make a separate commit for that?
