### PR TITLE
manual: Fix broken export rendering by org mistaking `=' for markup

### DIFF
--- a/docs/transient.org
+++ b/docs/transient.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Transient: (transient).
 #+TEXINFO_DIR_DESC: Transient Commands
-#+SUBTITLE: for version 0.1.0 (v0.1.0-101-ga6ce195+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-102-g9fb3f79+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -37,7 +37,7 @@ Calling a suffix command usually causes the transient to be exited
 but suffix commands can also be configured to not exit the transient.
 
 #+TEXINFO: @noindent
-This manual is for Transient version 0.1.0 (v0.1.0-101-ga6ce195+1).
+This manual is for Transient version 0.1.0 (v0.1.0-102-g9fb3f79+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -901,7 +901,7 @@ argument that is mandatory in all cases.
   used.
 
   Unless the class is specified explicitly, the appropriate class is
-  guessed based on the long argument.  If the argument ends with "="
+  guessed based on the long argument.  If the argument ends with "=​"
   (e.g. "--format=") then ~transient-option~ is used, otherwise
   ~transient-switch~.
 

--- a/docs/transient.texi
+++ b/docs/transient.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Transient User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-101-ga6ce195+1)
+@subtitle for version 0.1.0 (v0.1.0-102-g9fb3f79+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -65,7 +65,7 @@ Calling a suffix command usually causes the transient to be exited
 but suffix commands can also be configured to not exit the transient.
 
 @noindent
-This manual is for Transient version 0.1.0 (v0.1.0-101-ga6ce195+1).
+This manual is for Transient version 0.1.0 (v0.1.0-102-g9fb3f79+1).
 
 @quotation
 Copyright (C) 2018-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -1140,8 +1140,8 @@ Only the long argument is displayed in the popup buffer.  See
 used.
 
 Unless the class is specified explicitly, the appropriate class is
-guessed based on the long argument.  If the argument ends with "@samp{"
-  (e.g. "--format}") then @code{transient-option} is used, otherwise
+guessed based on the long argument.  If the argument ends with "=​"
+(e.g. "--format=") then @code{transient-option} is used, otherwise
 @code{transient-switch}.
 @end itemize
 


### PR DESCRIPTION
Cf. (info "(org)Escape Character")