### PR TITLE
Ensure 'value' can be referenced as :value

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -529,7 +529,7 @@ slot is non-nil."
   ((transient                         :initform t)
    (argument    :initarg :argument)
    (shortarg    :initarg :shortarg)
-   (value                             :initform nil)
+   (value       :initarg :value       :initform nil)
    (multi-value :initarg :multi-value :initform nil)
    (allow-empty :initarg :allow-empty :initform nil)
    (history-key :initarg :history-key :initform nil)


### PR DESCRIPTION
If we don't specify `:initarg` we end up not being able to write `(oref
obj :value)` (it complains about a missing slot). This fixes that.
