### PR TITLE
Use the package prefix for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the transient.
 A suffix command can, but does not have to, use the infix arguments in
 much the same way it can choose to use or ignore the prefix arguments.
 For a suffix command that was invoked from a transient the variable
-`current-transient-suffixes` and the function `transient-args` serve about
+`transient-current-suffixes` and the function `transient-args` serve about
 the same purpose as the variables `prefix-arg` and `current-prefix-arg` do
 for any command that was called after the prefix arguments have been
 set using a command such as `universal-argument`.

--- a/docs/transient.org
+++ b/docs/transient.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Transient: (transient).
 #+TEXINFO_DIR_DESC: Transient Commands
-#+SUBTITLE: for version 0.2.0 (v0.2.0-1-gafa0c2f+1)
+#+SUBTITLE: for version 0.2.0 (v0.2.0-8-gc94cff7+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -37,7 +37,7 @@ Calling a suffix command usually causes the transient to be exited
 but suffix commands can also be configured to not exit the transient.
 
 #+TEXINFO: @noindent
-This manual is for Transient version 0.2.0 (v0.2.0-1-gafa0c2f+1).
+This manual is for Transient version 0.2.0 (v0.2.0-8-gc94cff7+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -98,7 +98,7 @@ the transient.
 A suffix command can, but does not have to, use the infix arguments in
 much the same way it can choose to use or ignore the prefix arguments.
 For a suffix command that was invoked from a transient the variable
-~current-transient-suffixes~ and the function ~transient-args~ serve about
+~transient-current-suffixes~ and the function ~transient-args~ serve about
 the same purpose as the variables ~prefix-arg~ and ~current-prefix-arg~ do
 for any command that was called after the prefix arguments have been
 set using a command such as ~universal-argument~.
@@ -637,13 +637,13 @@ The following functions share a few arguments:
 - PREFIX is a transient prefix command, a symbol.
 
 - SUFFIX is a transient infix or suffix specification in the same form
-  as expected by ~define-transient-command~.  Note that an infix is a
+  as expected by ~transient-define-prefix~.  Note that an infix is a
   special kind of suffix.  Depending on context "suffixes" means
   "suffixes (including infixes)" or "non-infix suffixes".  Here it
   means the former.  See [[*Suffix Specifications]].
 
   SUFFIX may also be a group in the same form as expected by
-  ~define-transient-command~.  See [[*Group Specifications]].
+  ~transient-define-prefix~.  See [[*Group Specifications]].
 
 - LOC is a command, a key vector, a key description (a string as
   returned by ~key-description~), or a list specifying coordinates (the
@@ -710,7 +710,7 @@ binds the transient's infix and suffix commands.  In other words, it
 defines the complete transient, not just the transient prefix command
 that is used to invoke that transient.
 
-- Macro: define-transient-command name arglist [docstring] [keyword value]... group... [body...]
+- Macro: transient-define-prefix name arglist [docstring] [keyword value]... group... [body...]
 
   This macro defines NAME as a transient prefix command and binds the
   transient's infix and suffix commands.
@@ -758,7 +758,7 @@ that is used to invoke that transient.
 ** Binding Suffix and Infix Commands
 *** _ :ignore:
 
-The macro ~define-transient-command~ is used to define a transient.
+The macro ~transient-define-prefix~ is used to define a transient.
 This defines the actual transient prefix command (see [[*Defining
 Transients]]) and adds the transient's infix and suffix bindings, as
 described below.
@@ -767,7 +767,7 @@ Users and third-party packages can add additional bindings using
 functions such as ~transient-insert-suffix~ (See [[*Modifying Existing
 Transients]]).  These functions take a "suffix specification" as one of
 their arguments, which has the same form as the specifications used in
-~define-transient-command~.
+~transient-define-prefix~.
 
 *** Group Specifications
 
@@ -780,7 +780,7 @@ Several group classes exist, some of which organize suffixes in
 subgroups.  In most cases the class does not have to be specified
 explicitly, but see [[*Group Classes]].
 
-Groups are specified in the call to ~define-transient-command~, using
+Groups are specified in the call to ~transient-define-prefix~, using
 vectors.  Because groups are represented using vectors, we cannot use
 square brackets to indicate an optional element and instead use curly
 brackets to do the latter.
@@ -848,7 +848,7 @@ The form of suffix specifications is documented in the next node.
 *** Suffix Specifications
 
 A transient's suffix and infix commands are bound when the transient
-prefix command is defined using ~define-transient-command~, see
+prefix command is defined using ~transient-define-prefix~, see
 [[*Defining Transients]].  The commands are organized into groups, see
 [[*Group Specifications]].  Here we describe the form used to bind an
 individual suffix command.
@@ -889,8 +889,8 @@ argument that is mandatory in all cases.
 
 - COMMAND is a symbol that is bound as a function, which has to be a
   command.  Any command will do; it does not need to have an object
-  associated with it (as would be the case if ~define-suffix-command~
-  or ~define-infix-command~ were used to define it).
+  associated with it (as would be the case if ~transient-define-suffix~
+  or ~transient-define-infix~ were used to define it).
 
   As mentioned above, the object that is associated with a command can
   be used to set the default for certain values that otherwise have to
@@ -925,7 +925,7 @@ Note that an infix is a special kind of suffix. Depending on context
 "suffixes" means "suffixes (including infixes)" or "non-infix
 suffixes".
 
-- Macro: define-suffix-command name arglist [docstring] [keyword value]... body...
+- Macro: transient-define-suffix name arglist [docstring] [keyword value]... body...
 
   This macro defines NAME as a transient suffix command.
 
@@ -942,7 +942,7 @@ suffixes".
   The infix arguments are usually accessed by using ~transient-args~
   inside ~interactive~.
 
-- Macro: define-infix-command name arglist [docstring] [keyword value]...
+- Macro: transient-define-infix name arglist [docstring] [keyword value]...
 
   This macro defines NAME as a transient infix command.
 
@@ -979,14 +979,14 @@ suffixes".
   ~transient-suffix-command~ to define the infix command and use ~t~ as
   the value of the ~:transient~ keyword.
 
-- Macro: define-infix-argument name arglist [docstring] [keyword value]...
+- Macro: transient-define-argument name arglist [docstring] [keyword value]...
 
   This macro defines NAME as a transient infix command.
 
-  It is an alias for ~define-infix-command~.  Only use this alias
+  This is an alias for ~transient-define-infix~.  Only use this alias
   to define an infix command that actually sets an infix argument.
   To define an infix command that, for example, sets a variable, use
-  ~define-infix-command~ instead.
+  ~transient-define-infix~ instead.
 
 ** Using Infix Arguments
 
@@ -1016,7 +1016,7 @@ function, which for infix arguments serves about the same purpose as
   command was not invoked from PREFIX, then it returns the set, saved
   or default value for PREFIX.
 
-- Variable: current-transient-suffixes
+- Variable: transient-current-suffixes
 
   The suffixes of the transient from which this suffix command was
   invoked.  This is a list of objects.  Usually it is sufficient to
@@ -1024,13 +1024,13 @@ function, which for infix arguments serves about the same purpose as
   values.  In complex cases it might be necessary to use this variable
   instead, i.e. if you need access to information beside the value.
 
-- Variable: current-transient-prefix
+- Variable: transient-current-prefix
 
   The transient from which this suffix command was invoked.  The
   returned value is a ~transient-prefix~ object, which holds information
   associated with the transient prefix command.
 
-- Variable: current-transient-command
+- Variable: transient-current-command
 
   The transient from which this suffix command was invoked.  The
   returned value is a symbol, the transient prefix command.
@@ -1232,7 +1232,7 @@ This happens in two ways.
 
 The type of a group can be specified using the ~:class~ property at the
 beginning of the class specification, e.g. ~[:class transient-columns
-...]~ in a call to ~define-transient-command~.
+...]~ in a call to ~transient-define-prefix~.
 
 - The abstract ~transient-child~ class is the base class of both
   ~transient-group~ (and therefore all groups) as well as of
@@ -1485,7 +1485,7 @@ functions use ~describe-function~.
   causes the others to be disabled.
 
 - ~scope~ For some transients it might be necessary to have a sort of
-  secondary value, called a "scope".  See ~define-transient-command~.
+  secondary value, called a "scope".  See ~transient-define-prefix~.
 
 *** Internal Prefix Slots
 :PROPERTIES:
@@ -1493,7 +1493,7 @@ functions use ~describe-function~.
 :END:
 
 These slots are mostly intended for internal use.  They should not be
-set in calls to ~define-transient-command~.
+set in calls to ~transient-define-prefix~.
 
 - ~prototype~ When a transient prefix command is invoked, then a clone
   of that object is stored in the global variable ~transient--prefix~
@@ -1889,7 +1889,7 @@ command dispatchers:
   using the current interface:
 
   #+BEGIN_SRC emacs-lisp
-    (define-transient-command outline-navigate ()
+    (transient-define-prefix outline-navigate ()
       :transient-suffix     'transient--do-stay
       :transient-non-suffix 'transient--do-warn
       [("p" "previous visible heading" outline-previous-visible-heading)

--- a/docs/transient.texi
+++ b/docs/transient.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Transient User and Developer Manual
-@subtitle for version 0.2.0 (v0.2.0-1-gafa0c2f+1)
+@subtitle for version 0.2.0 (v0.2.0-8-gc94cff7+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -65,7 +65,7 @@ Calling a suffix command usually causes the transient to be exited
 but suffix commands can also be configured to not exit the transient.
 
 @noindent
-This manual is for Transient version 0.2.0 (v0.2.0-1-gafa0c2f+1).
+This manual is for Transient version 0.2.0 (v0.2.0-8-gc94cff7+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -197,7 +197,7 @@ the transient.
 A suffix command can, but does not have to, use the infix arguments in
 much the same way it can choose to use or ignore the prefix arguments.
 For a suffix command that was invoked from a transient the variable
-@code{current-transient-suffixes} and the function @code{transient-args} serve about
+@code{transient-current-suffixes} and the function @code{transient-args} serve about
 the same purpose as the variables @code{prefix-arg} and @code{current-prefix-arg} do
 for any command that was called after the prefix arguments have been
 set using a command such as @code{universal-argument}.
@@ -833,13 +833,13 @@ PREFIX is a transient prefix command, a symbol.
 
 @item
 SUFFIX is a transient infix or suffix specification in the same form
-as expected by @code{define-transient-command}.  Note that an infix is a
+as expected by @code{transient-define-prefix}.  Note that an infix is a
 special kind of suffix.  Depending on context "suffixes" means
 "suffixes (including infixes)" or "non-infix suffixes".  Here it
 means the former.  See @ref{Suffix Specifications}.
 
 SUFFIX may also be a group in the same form as expected by
-@code{define-transient-command}.  See @ref{Group Specifications}.
+@code{transient-define-prefix}.  See @ref{Group Specifications}.
 
 
 @item
@@ -926,7 +926,7 @@ binds the transient's infix and suffix commands.  In other words, it
 defines the complete transient, not just the transient prefix command
 that is used to invoke that transient.
 
-@defmac define-transient-command name arglist [docstring] [keyword value]@dots{} group@dots{} [body@dots{}]
+@defmac transient-define-prefix name arglist [docstring] [keyword value]@dots{} group@dots{} [body@dots{}]
 
 This macro defines NAME as a transient prefix command and binds the
 transient's infix and suffix commands.
@@ -975,14 +975,14 @@ the branch whose variables are being configured.
 @node Binding Suffix and Infix Commands
 @section Binding Suffix and Infix Commands
 
-The macro @code{define-transient-command} is used to define a transient.
+The macro @code{transient-define-prefix} is used to define a transient.
 This defines the actual transient prefix command (see @ref{Defining Transients}) and adds the transient's infix and suffix bindings, as
 described below.
 
 Users and third-party packages can add additional bindings using
 functions such as @code{transient-insert-suffix} (See @ref{Modifying Existing Transients}).  These functions take a "suffix specification" as one of
 their arguments, which has the same form as the specifications used in
-@code{define-transient-command}.
+@code{transient-define-prefix}.
 
 @menu
 * Group Specifications::
@@ -1001,7 +1001,7 @@ Several group classes exist, some of which organize suffixes in
 subgroups.  In most cases the class does not have to be specified
 explicitly, but see @ref{Group Classes}.
 
-Groups are specified in the call to @code{define-transient-command}, using
+Groups are specified in the call to @code{transient-define-prefix}, using
 vectors.  Because groups are represented using vectors, we cannot use
 square brackets to indicate an optional element and instead use curly
 brackets to do the latter.
@@ -1078,7 +1078,7 @@ The form of suffix specifications is documented in the next node.
 @subsection Suffix Specifications
 
 A transient's suffix and infix commands are bound when the transient
-prefix command is defined using @code{define-transient-command}, see
+prefix command is defined using @code{transient-define-prefix}, see
 @ref{Defining Transients}.  The commands are organized into groups, see
 @ref{Group Specifications}.  Here we describe the form used to bind an
 individual suffix command.
@@ -1127,8 +1127,8 @@ argument that is mandatory in all cases.
 @item
 COMMAND is a symbol that is bound as a function, which has to be a
 command.  Any command will do; it does not need to have an object
-associated with it (as would be the case if @code{define-suffix-command}
-or @code{define-infix-command} were used to define it).
+associated with it (as would be the case if @code{transient-define-suffix}
+or @code{transient-define-infix} were used to define it).
 
 As mentioned above, the object that is associated with a command can
 be used to set the default for certain values that otherwise have to
@@ -1166,7 +1166,7 @@ Note that an infix is a special kind of suffix. Depending on context
 "suffixes" means "suffixes (including infixes)" or "non-infix
 suffixes".
 
-@defmac define-suffix-command name arglist [docstring] [keyword value]@dots{} body@dots{}
+@defmac transient-define-suffix name arglist [docstring] [keyword value]@dots{} body@dots{}
 
 This macro defines NAME as a transient suffix command.
 
@@ -1184,7 +1184,7 @@ The infix arguments are usually accessed by using @code{transient-args}
 inside @code{interactive}.
 @end defmac
 
-@defmac define-infix-command name arglist [docstring] [keyword value]@dots{}
+@defmac transient-define-infix name arglist [docstring] [keyword value]@dots{}
 
 This macro defines NAME as a transient infix command.
 
@@ -1222,14 +1222,14 @@ define your own infix command class.  In that case you have to use
 the value of the @code{:transient} keyword.
 @end defmac
 
-@defmac define-infix-argument name arglist [docstring] [keyword value]@dots{}
+@defmac transient-define-argument name arglist [docstring] [keyword value]@dots{}
 
 This macro defines NAME as a transient infix command.
 
-It is an alias for @code{define-infix-command}.  Only use this alias
+This is an alias for @code{transient-define-infix}.  Only use this alias
 to define an infix command that actually sets an infix argument.
 To define an infix command that, for example, sets a variable, use
-@code{define-infix-command} instead.
+@code{transient-define-infix} instead.
 @end defmac
 
 @node Using Infix Arguments
@@ -1262,7 +1262,7 @@ command was not invoked from PREFIX, then it returns the set, saved
 or default value for PREFIX@.
 @end defun
 
-@defvar current-transient-suffixes
+@defvar transient-current-suffixes
 
 The suffixes of the transient from which this suffix command was
 invoked.  This is a list of objects.  Usually it is sufficient to
@@ -1271,14 +1271,14 @@ values.  In complex cases it might be necessary to use this variable
 instead, i.e. if you need access to information beside the value.
 @end defvar
 
-@defvar current-transient-prefix
+@defvar transient-current-prefix
 
 The transient from which this suffix command was invoked.  The
 returned value is a @code{transient-prefix} object, which holds information
 associated with the transient prefix command.
 @end defvar
 
-@defvar current-transient-command
+@defvar transient-current-command
 
 The transient from which this suffix command was invoked.  The
 returned value is a symbol, the transient prefix command.
@@ -1516,7 +1516,7 @@ differ even between different commands of the same type.
 
 The type of a group can be specified using the @code{:class} property at the
 beginning of the class specification, e.g. @code{[:class transient-columns
-...]} in a call to @code{define-transient-command}.
+...]} in a call to @code{transient-define-prefix}.
 
 @itemize
 @item
@@ -1832,13 +1832,13 @@ causes the others to be disabled.
 
 @item
 @code{scope} For some transients it might be necessary to have a sort of
-secondary value, called a "scope".  See @code{define-transient-command}.
+secondary value, called a "scope".  See @code{transient-define-prefix}.
 @end itemize
 
 @subsection Internal Prefix Slots
 
 These slots are mostly intended for internal use.  They should not be
-set in calls to @code{define-transient-command}.
+set in calls to @code{transient-define-prefix}.
 
 @itemize
 @item
@@ -2305,7 +2305,7 @@ and the interface is a bit more complicated.  A very basic example
 using the current interface:
 
 @lisp
-(define-transient-command outline-navigate ()
+(transient-define-prefix outline-navigate ()
   :transient-suffix     'transient--do-stay
   :transient-non-suffix 'transient--do-warn
   [("p" "previous visible heading" outline-previous-visible-heading)

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -935,6 +935,7 @@ example, sets a variable use `transient-define-infix' instead.
         (append  (setcdr mem (cons suf (cdr mem))))
         (replace (setcar mem suf)))))))
 
+;;;###autoload
 (defun transient-insert-suffix (prefix loc suffix)
   "Insert a SUFFIX into PREFIX before LOC.
 PREFIX is a prefix command, a symbol.
@@ -947,6 +948,7 @@ See info node `(transient)Modifying Existing Transients'."
   (declare (indent defun))
   (transient--insert-suffix prefix loc suffix 'insert))
 
+;;;###autoload
 (defun transient-append-suffix (prefix loc suffix)
   "Insert a SUFFIX into PREFIX after LOC.
 PREFIX is a prefix command, a symbol.
@@ -959,6 +961,7 @@ See info node `(transient)Modifying Existing Transients'."
   (declare (indent defun))
   (transient--insert-suffix prefix loc suffix 'append))
 
+;;;###autoload
 (defun transient-replace-suffix (prefix loc suffix)
   "Replace the suffix at LOC in PREFIX with SUFFIX.
 PREFIX is a prefix command, a symbol.
@@ -971,6 +974,7 @@ See info node `(transient)Modifying Existing Transients'."
   (declare (indent defun))
   (transient--insert-suffix prefix loc suffix 'replace))
 
+;;;###autoload
 (defun transient-remove-suffix (prefix loc)
   "Remove the suffix or group at LOC in PREFIX.
 PREFIX is a prefix command, a symbol.

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -64,6 +64,24 @@
 
 (defvar Man-notify-method)
 
+(define-obsolete-function-alias 'define-transient-command
+  'transient-define-prefix "Transient 0.3.0")
+(define-obsolete-function-alias 'define-suffix-command
+  'transient-define-suffix "Transient 0.3.0")
+(define-obsolete-function-alias 'define-infix-command
+  'transient-define-infix "Transient 0.3.0")
+(define-obsolete-function-alias 'define-infix-argument
+  'transient-define-argument "Transient 0.3.0")
+
+(define-obsolete-variable-alias 'current-transient-prefix
+  'transient-current-prefix "Transient 0.3.0")
+(define-obsolete-variable-alias 'current-transient-command
+  'transient-current-command "Transient 0.3.0")
+(define-obsolete-variable-alias 'current-transient-suffixes
+  'transient-current-suffixes "Transient 0.3.0")
+(define-obsolete-variable-alias 'post-transient-hook
+  'transient-exit-hook "Transient 0.3.0")
+
 ;;; Options
 
 (defgroup transient nil
@@ -599,7 +617,7 @@ elements themselves.")
 
 ;;; Define
 
-(defmacro define-transient-command (name arglist &rest args)
+(defmacro transient-define-prefix (name arglist &rest args)
   "Define NAME as a transient prefix command.
 
 ARGLIST are the arguments that command takes.
@@ -662,7 +680,7 @@ to the setup function:
             ',(cl-mapcan (lambda (s) (transient--parse-child name s))
                          suffixes)))))
 
-(defmacro define-suffix-command (name arglist &rest args)
+(defmacro transient-define-suffix (name arglist &rest args)
   "Define NAME as a transient suffix command.
 
 ARGLIST are the arguments that the command takes.
@@ -694,7 +712,7 @@ ARGLIST.  The infix arguments are usually accessed by using
        (put ',name 'transient--suffix
             (,(or class 'transient-suffix) :command ',name ,@slots)))))
 
-(defmacro define-infix-command (name _arglist &rest args)
+(defmacro transient-define-infix (name _arglist &rest args)
   "Define NAME as a transient infix command.
 
 ARGLIST is always ignored and reserved for future use.
@@ -742,12 +760,12 @@ keyword.
        (put ',name 'transient--suffix
             (,(or class 'transient-switch) :command ',name ,@slots)))))
 
-(defalias 'define-infix-argument 'define-infix-command
+(defalias 'transient-define-argument 'define-infix-command
   "Define NAME as a transient infix command.
 
 Only use this alias to define an infix command that actually
 sets an infix argument.  To define a infix command that, for
-example, sets a variable use `define-infix-command' instead.
+example, sets a variable use `transient-define-infix' instead.
 
 \(fn NAME ARGLIST [DOCSTRING] [KEYWORD VALUE]...)")
 
@@ -921,7 +939,7 @@ example, sets a variable use `define-infix-command' instead.
   "Insert a SUFFIX into PREFIX before LOC.
 PREFIX is a prefix command, a symbol.
 SUFFIX is a suffix command or a group specification (of
-  the same forms as expected by `define-transient-command').
+  the same forms as expected by `transient-define-prefix').
 LOC is a command, a key vector, a key description (a string
   as returned by `key-description'), or a coordination list
   (whose last element may also be a command or key).
@@ -933,7 +951,7 @@ See info node `(transient)Modifying Existing Transients'."
   "Insert a SUFFIX into PREFIX after LOC.
 PREFIX is a prefix command, a symbol.
 SUFFIX is a suffix command or a group specification (of
-  the same forms as expected by `define-transient-command').
+  the same forms as expected by `transient-define-prefix').
 LOC is a command, a key vector, a key description (a string
   as returned by `key-description'), or a coordination list
   (whose last element may also be a command or key).
@@ -945,7 +963,7 @@ See info node `(transient)Modifying Existing Transients'."
   "Replace the suffix at LOC in PREFIX with SUFFIX.
 PREFIX is a prefix command, a symbol.
 SUFFIX is a suffix command or a group specification (of
-  the same forms as expected by `define-transient-command').
+  the same forms as expected by `transient-define-prefix').
 LOC is a command, a key vector, a key description (a string
   as returned by `key-description'), or a coordination list
   (whose last element may also be a command or key).
@@ -978,7 +996,7 @@ See info node `(transient)Modifying Existing Transients'."
   "Edit the suffix at LOC in PREFIX, setting PROP to VALUE.
 PREFIX is a prefix command, a symbol.
 SUFFIX is a suffix command or a group specification (of
-  the same forms as expected by `define-transient-command').
+  the same forms as expected by `transient-define-prefix').
 LOC is a command, a key vector, a key description (a string
   as returned by `key-description'), or a coordination list
   (whose last element may also be a command or key).
@@ -1060,24 +1078,24 @@ See info node `(transient)Modifying Existing Transients'."
 
 ;;; Variables
 
-(defvar current-transient-prefix nil
+(defvar transient-current-prefix nil
   "The transient from which this suffix command was invoked.
 This is an object representing that transient, use
-`current-transient-command' to get the respective command.")
+`transient-current-command' to get the respective command.")
 
-(defvar current-transient-command nil
+(defvar transient-current-command nil
   "The transient from which this suffix command was invoked.
 This is a symbol representing that transient, use
 `current-transient-object' to get the respective object.")
 
-(defvar current-transient-suffixes nil
+(defvar transient-current-suffixes nil
   "The suffixes of the transient from which this suffix command was invoked.
 This is a list of objects.  Usually it is sufficient to instead
 use the function `transient-args', which returns a list of
 values.  In complex cases it might be necessary to use this
 variable instead.")
 
-(defvar post-transient-hook nil
+(defvar transient-exit-hook nil
   "Hook run after exiting a transient.")
 
 (defvar transient--prefix nil)
@@ -1136,7 +1154,7 @@ the case of an infix command, which is a kind of suffix command).
 
 This function is intended to be called by infix commands, whose
 command definition usually (at least when defined using
-`define-infix-command') is this:
+`transient-define-infix') is this:
 
    (lambda ()
      (interactive)
@@ -1487,7 +1505,7 @@ EDIT may be non-nil."
     (setq name (oref transient--prefix command))
     (setq params (list :scope (oref transient--prefix scope))))
    ((not (or layout                      ; resuming parent/suspended prefix
-             current-transient-command)) ; entering child prefix
+             transient-current-command)) ; entering child prefix
     (transient--stack-zap))              ; replace suspended prefix, if any
    (edit
     ;; Returning from help to edit.
@@ -1702,9 +1720,9 @@ EDIT may be non-nil."
       (kill-buffer buf))))
 
 (defun transient--export ()
-  (setq current-transient-prefix transient--prefix)
-  (setq current-transient-command (oref transient--prefix command))
-  (setq current-transient-suffixes transient--suffixes)
+  (setq transient-current-prefix transient--prefix)
+  (setq transient-current-command (oref transient--prefix command))
+  (setq transient-current-suffixes transient--suffixes)
   (transient--history-push transient--prefix))
 
 (defun transient--minibuffer-setup ()
@@ -1760,15 +1778,15 @@ EDIT may be non-nil."
           (remove-hook   'minibuffer-exit-hook  #'transient--minibuffer-exit)
           (advice-remove 'abort-recursive-edit  #'transient--minibuffer-exit)
           (remove-hook   'post-command-hook     #'transient--post-command))
-        (setq current-transient-prefix nil)
-        (setq current-transient-command nil)
-        (setq current-transient-suffixes nil)
+        (setq transient-current-prefix nil)
+        (setq transient-current-command nil)
+        (setq transient-current-suffixes nil)
         (let ((resume (and transient--stack
                            (not (memq transient--exitp '(replace suspend))))))
           (setq transient--exitp nil)
           (setq transient--helpp nil)
           (setq transient--editp nil)
-          (run-hooks 'post-transient-hook)
+          (run-hooks 'transient-exit-hook)
           (when resume
             (transient--stack-pop))))
     (transient--pop-keymap 'transient--redisplay-map)
@@ -2029,12 +2047,12 @@ transient is active."
 (defun transient-set ()
   "Save the value of the active transient for this Emacs session."
   (interactive)
-  (transient-set-value (or transient--prefix current-transient-prefix)))
+  (transient-set-value (or transient--prefix transient-current-prefix)))
 
 (defun transient-save ()
   "Save the value of the active transient persistenly across Emacs sessions."
   (interactive)
-  (transient-save-value (or transient--prefix current-transient-prefix)))
+  (transient-save-value (or transient--prefix transient-current-prefix)))
 
 (defun transient-history-next ()
   "Switch to the next value used for the active transient."
@@ -2396,8 +2414,8 @@ If the current command was invoked from the transient prefix
 command PREFIX, then return the active infix arguments.  If
 the current command was not invoked from PREFIX, then return
 the set, saved or default value for PREFIX."
-  (if (eq current-transient-command prefix)
-      (delq nil (mapcar 'transient-infix-value current-transient-suffixes))
+  (if (eq transient-current-command prefix)
+      (delq nil (mapcar 'transient-infix-value transient-current-suffixes))
     (let ((transient--prefix nil)
           (transient--layout nil)
           (transient--suffixes nil))
@@ -2405,7 +2423,7 @@ the set, saved or default value for PREFIX."
       (delq nil (mapcar 'transient-infix-value transient--suffixes)))))
 
 (defun transient-get-value ()
-  (delq nil (mapcar 'transient-infix-value current-transient-suffixes)))
+  (delq nil (mapcar 'transient-infix-value transient-current-suffixes)))
 
 (cl-defgeneric transient-infix-value (obj)
   "Return the value of the suffix object OBJ.
@@ -3130,12 +3148,12 @@ search instead."
 (defun transient--suspend-which-key-mode ()
   (when (bound-and-true-p which-key-mode)
     (which-key-mode -1)
-    (add-hook 'post-transient-hook 'transient--resume-which-key-mode)))
+    (add-hook 'transient-exit-hook 'transient--resume-which-key-mode)))
 
 (defun transient--resume-which-key-mode ()
   (unless transient--prefix
     (which-key-mode 1)
-    (remove-hook 'post-transient-hook 'transient--resume-which-key-mode)))
+    (remove-hook 'transient-exit-hook 'transient--resume-which-key-mode)))
 
 (defun transient-bind-q-to-quit ()
   "Modify some keymaps to bind \"q\" to the appropriate quit command.
@@ -3185,10 +3203,10 @@ we stop there."
 (defconst transient-font-lock-keywords
   (eval-when-compile
     `((,(concat "("
-                (regexp-opt (list "define-transient-command"
-                                  "define-infix-command"
-                                  "define-infix-argument"
-                                  "define-suffix-command")
+                (regexp-opt (list "transient-define-prefix"
+                                  "transient-define-infix"
+                                  "transient-define-argument"
+                                  "transient-define-suffix")
                             t)
                 "\\_>[ \t'\(]*"
                 "\\(\\(?:\\sw\\|\\s_\\)+\\)?")


### PR DESCRIPTION
I am adding `transient` to GNU Elpa and Stefan suggested that some I rename some macros and variables so that everything uses the `transient-` prefix.  After some initial resistance I have come around to the idea.

@kyleam @npostavs and comments?

(Just so you don't waste any time on duplicated work: I have already adjusted `magit` and @kyleam's extensions.)