### PR TITLE
Show the correct backtrace when taking the emergency exit

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -93,7 +93,9 @@
   (declare (indent defun))
   `(condition-case err
        ,(macroexp-progn body)
-     (error (transient--emergency-exit err))))
+     (error
+      (transient--emergency-exit)
+      (signal (car err) (cdr err)))))
 
 ;;; Options
 
@@ -2005,7 +2007,7 @@ value.  Otherwise return CHILDREN as is."
                  arg this-command transient--exitp)
       (apply #'message arg args))))
 
-(defun transient--emergency-exit (&optional err)
+(defun transient--emergency-exit ()
   "Exit the current transient command after an error occurred.
 
 Beside being used with `condition-case', this function also has
@@ -2021,9 +2023,7 @@ nil, then do nothing."
     (setq transient--stack nil)
     (setq transient--exitp t)
     (transient--pre-exit)
-    (transient--post-command))
-  (when err
-    (signal (car err) (cdr err))))
+    (transient--post-command)))
 
 (add-hook 'debugger-mode-hook 'transient--emergency-exit)
 

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -93,7 +93,7 @@
   (declare (indent defun))
   `(condition-case err
        ,(macroexp-progn body)
-     (error
+     ((debug error)
       (transient--emergency-exit)
       (signal (car err) (cdr err)))))
 


### PR DESCRIPTION
When an error occurs during the creation of the transient, then we must make sure to undo all setup because Emacs could otherwise we left in a state that makes it necessary to kill it. Still, we would like a backtrace about the actual error.

@npostavs While searching for inspiration on how to do this I kept running into replies by you, so I was wondering if you could have a look here as well.

To easily try this out signal an error near the end of `transient-setup`, if you can still use Emacs as usual after that, then the emergency exit was most likely taken as intended.

```
Debugger entered: ((error (error "autsch")))
  (transient--exit-and-debug error (error "autsch"))
  (error "autsch")
  (progn (cond ((not name) (transient--pop-keymap 'transient--transient-map) (transient--pop-keymap 'transient--redisplay-map) (setq name (eieio-oref transient--prefix 'command)) (setq params (list :scope (eieio-oref transient--prefix 'scope)))) ((not (or layout transient-current-command)) (transient--stack-zap)) (edit (setq transient--editp t))) (transient--init-objects name layout params) (transient--history-init transient--prefix) (setq transient--predicate-map (transient--make-predicate-map)) (setq transient--transient-map (transient--make-transient-map)) (setq transient--redisplay-map (transient--make-redisplay-map)) (setq transient--original-window (selected-window)) (setq transient--original-buffer (current-buffer)) (transient--redisplay) (transient--init-transient) (transient--suspend-which-key-mode) (error "autsch"))
  (let ((debugger #'transient--disable-transient-state-and-debug)) (progn (cond ((not name) (transient--pop-keymap 'transient--transient-map) (transient--pop-keymap 'transient--redisplay-map) (setq name (eieio-oref transient--prefix 'command)) (setq params (list :scope (eieio-oref transient--prefix 'scope)))) ((not (or layout transient-current-command)) (transient--stack-zap)) (edit (setq transient--editp t))) (transient--init-objects name layout params) (transient--history-init transient--prefix) (setq transient--predicate-map (transient--make-predicate-map)) (setq transient--transient-map (transient--make-transient-map)) (setq transient--redisplay-map (transient--make-redisplay-map)) (setq transient--original-window (selected-window)) (setq transient--original-buffer (current-buffer)) (transient--redisplay) (transient--init-transient) (transient--suspend-which-key-mode) (error "autsch")))
  (condition-case err (let ((debugger #'transient--disable-transient-state-and-debug)) (progn (cond ((not name) (transient--pop-keymap 'transient--transient-map) (transient--pop-keymap 'transient--redisplay-map) (setq name (eieio-oref transient--prefix 'command)) (setq params (list :scope (eieio-oref transient--prefix ...)))) ((not (or layout transient-current-command)) (transient--stack-zap)) (edit (setq transient--editp t))) (transient--init-objects name layout params) (transient--history-init transient--prefix) (setq transient--predicate-map (transient--make-predicate-map)) (setq transient--transient-map (transient--make-transient-map)) (setq transient--redisplay-map (transient--make-redisplay-map)) (setq transient--original-window (selected-window)) (setq transient--original-buffer (current-buffer)) (transient--redisplay) (transient--init-transient) (transient--suspend-which-key-mode) (error "autsch"))) ((debug error) (transient--emergency-exit err)))
  (transient-setup magit-diff)
  (magit-diff)
  (funcall-interactively magit-diff)
  (command-execute magit-diff)
```

Do you have any suggestions?  What is the correct way to prevent `(transient--exit-and-debug error (error "autsch"))` from appearing in the backtrace?