### PR TITLE
Add /docs/*.info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /config.mk
 /docs/*.html
+/docs/*.info
 /docs/*.pdf
 /docs/dir
 /docs/transient/


### PR DESCRIPTION
When updating .emacs.g from emacscollective, git complains that
transient is dirty because docs/transient.info is untracked.
