### PR TITLE
transient-infix-read: Enable reading values while in minibuffer

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2462,14 +2462,18 @@ it\", in which case it is pointless to preserve history.)"
                           (cons 'transient--history 1)
                         'transient--history))
              (value
-              (cond
-               (reader (funcall reader prompt initial-input history))
-               (multi-value
-                (completing-read-multiple prompt choices nil nil
-                                          initial-input history))
-               (choices
-                (completing-read prompt choices nil t initial-input history))
-               (t (read-string prompt initial-input history)))))
+              (let* ((enable-recursive-minibuffers t)
+                     (_ (transient--suspend-override t))
+                     (input (cond
+                             (reader (funcall reader prompt initial-input history))
+                             (multi-value
+                              (completing-read-multiple prompt choices nil nil
+                                                        initial-input history))
+                             (choices
+                              (completing-read prompt choices nil t initial-input history))
+                             (t (read-string prompt initial-input history))))
+                     (_ (transient--resume-override t)))
+                input)))
         (cond ((and (equal value "") (not allow-empty))
                (setq value nil))
               ((and (equal value "\"\"") allow-empty)


### PR DESCRIPTION
While creating a **transient** interface for [consult-grep](https://github.com/minad/consult) I'm trying to create a popup that you can toggle while you're executing the **consult-grep** command from the minibuffer, to manage the args.

While doing this I noticed that the arguments that try to get some input from the minibuffer don't work for two reasons:
- You need `(enable-recursive-minibuffers t)`
- Even after enabling this, when the minibuffer is expecting you to input the value of the option, it seems that the transient bindings are still active so it's not possible to write anything

![Unbound suffix](https://user-images.githubusercontent.com/1837971/105333506-1b0e8f00-5bd6-11eb-856b-87b9ed78b0ba.png)

To prevent this I created a custom **reader** that enables recursive minibuffers and suspends transient override. I prepared a simple example to show the problem:
- `-t` works because it doesn't read anything from the minibuffer
- `-c` works because it uses a custom reader
- `-o` doesn't work because it uses one of the default readers

```elisp
(require 'transient)

(defun gx-test ()
  "Read something."
  (interactive)
  (let ((input (read-string "Something: ")))
    (message "Something: '%S'" input)))

(define-transient-command gx-popup ()
  "Test popup."
  ["Args"
   ("-t" "Toggle" "--toggle")
   ("-o" "Option with default reader" "--option=" :class transient-option)
   ("-c" "Option with custom reader" "--custom=" :class transient-option :reader gx-popup--reader)]
  ["Test"
   ("t" "test" gx-popup-test)])

(defun gx-popup--reader (prompt initial-input history)
  "Read something in the popup."
  (transient--suspend-override t)
  (let* ((enable-recursive-minibuffers t)
         (input (transient-read-number-N+ prompt initial-input history)))
    (transient--resume-override t)
    input))

(defun gx-popup-test ()
  "Execute something."
  (interactive)
  (let ((args (transient-args 'gx-popup)))
    (message "args: %S" args)))

(define-key minibuffer-local-map (kbd "M-h") #'gx-popup)
```

This pr tries to solve this problem by toggling `enable-recursive-minibuffers` and using `transient--suspend-override` while reading from the minibuffer in the default `transient-infix-read`.