### PR TITLE
Add a generic help-command

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -547,6 +547,7 @@ If `transient-save-history' is nil, then do nothing."
    (history-pos :initarg :history-pos :initform 0)
    (history-key :initarg :history-key :initform nil)
    (man-page    :initarg :man-page    :initform nil)
+   (help-command    :initarg :help-command    :initform nil)
    (info-manual :initarg :info-manual :initform nil)
    (transient-suffix     :initarg :transient-suffix     :initform nil)
    (transient-non-suffix :initarg :transient-non-suffix :initform nil)
@@ -3188,7 +3189,9 @@ Show the first one that is specified."
       (info manual)
     (if-let ((manpage (oref obj man-page)))
         (transient--show-manpage manpage)
-      (transient--describe-function (oref obj command)))))
+      (if-let ((helpcommand (oref obj help-command)))
+          (transient--show-helpcommand helpcommand)
+      (transient--describe-function (oref obj command))))))
 
 (cl-defmethod transient-show-help ((_   transient-suffix))
   "Show the command doc-string."
@@ -3221,6 +3224,12 @@ location."
     (switch-to-buffer buf)
     (when argument
       (transient--goto-argument-description argument))))
+
+(defun transient--show-helpcommand (helpcommand)
+  (let* ((process "*transient-helpcommand*")
+         (buffer "*transient-helpcommand-buffer*"))
+    (call-process-shell-command helpcommand nil buffer)
+    (switch-to-buffer buffer)))
 
 (defun transient--describe-function (fn)
   (describe-function fn)


### PR DESCRIPTION
I am trying to write a transient-based Emacs extension for the Kaggle command-line utility. Such a utility does not have a man page--much less an info manual--, so the two transient-prefix documentation options are not suitable.

As such, I needed to pass a custom shell command (in the case of kaggle, it is kaggle -h), to display the help message from the utility. So I added a new option `:help-command` that receives a shell command to call to get the help message, and displays it into a new buffer, akin to the existing two options, `:man-page` and `:info-manual`. I am not sure such a modification is useful--I did not find any previous discussion whatsoever--, so this is a pull request as well as kind of an issue.

This is also my first time writing some more serious elisp code, so the functions used are surely not the best ones, because I have yet to learn all the nuances of the language. If this is useful, I will follow the indications to make additional necessary changes.