### PR TITLE
Allow Arguments to Appear in More than one sub-list of :incompatible

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2695,7 +2695,11 @@ prompt."
                (oref obj argument-regexp))))
     (if-let ((sic (and value arg transient--unset-incompatible))
              (spec (oref transient--prefix incompatible))
-             (incomp (remove arg (cl-find-if (lambda (elt) (member arg elt)) spec))))
+             (incomp-matching (cl-remove-if-not
+                               (lambda (elt) (member arg elt)) spec))
+             (incomp (cl-reduce
+                      #'append
+                      (mapcar (lambda (e) (remove arg e)) incomp-matching))))
         (progn
           (cl-call-next-method obj value)
           (dolist (arg incomp)


### PR DESCRIPTION
Hi, this PR is a proposed fix for #129/#155.  It addresses the case where for example `:incompatible` is passed something like `'(("-a" "-b") ("-a" "-c"))`, and only the first sublist would be taken into account, so you could have `"-a" "-c"` both active at the same time.

The solution used here is to just concatenate the contents of all lists that an argument occurs in instead of taking only the first.

I've put together a demonstration of the change with a modified version of the example in #155 here: https://gist.github.com/LaurenceWarne/af3e48ee9f2d6b2a14bea04dd458ccf6.