### PR TITLE
Add missed `(require 'edmacro)`

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -56,6 +56,7 @@
 (require 'eieio)
 (require 'format-spec)
 (require 'seq)
+(require 'edmacro)
 
 (eval-when-compile
   (require 'subr-x))


### PR DESCRIPTION
This trivial change fixes https://github.com/hlissner/doom-emacs/issues/5670
