### PR TITLE
transient--show: Also hide the header-line

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -3182,6 +3182,7 @@ have a history of their own.")
       (setq window-size-fixed t)
       (when (bound-and-true-p tab-line-format)
         (setq tab-line-format nil))
+      (setq header-line-format nil)
       (setq mode-line-format (if (eq transient-mode-line-format 'line)
                                  nil
                                transient-mode-line-format))


### PR DESCRIPTION
Some Emacs users move the content of the mode-line to the
header-line. This is also what nano-modeline [1] does by
default. `transient--show` hides the mode-line and the tab-line but
not the header-line. As a result, the last line of transient buffers
are invisible for these users. Hiding the header-line fixes the issue.

## Before

![2022-04-23-103530](https://user-images.githubusercontent.com/217543/164887161-62acdc89-9846-4348-be11-1dc81b91cd93.png)

## After

![2022-04-23-103446](https://user-images.githubusercontent.com/217543/164887166-581498e9-9568-4f5a-8670-f52371d36014.png)

This is not perfect because nothing separates the transient buffer from the buffer above but this is still a good progress.