### PR TITLE
Allow transient-switches to have descriptions for choices

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2877,7 +2877,12 @@ it\", in which case it is pointless to preserve history.)"
   "Cycle through the mutually exclusive switches.
 The last value is \"don't use any of these switches\"."
   (let ((choices (mapcar (apply-partially #'format (oref obj argument-format))
-                         (oref obj choices))))
+                         (mapcar
+                          (lambda (x)
+                            ;; Return car of X if it is a cons
+                            ;; otherwise return X.
+                            (if (consp x) (car x) x))
+                          (oref obj choices)))))
     (if-let ((value (oref obj value)))
         (cadr (member value choices))
       (car choices))))
@@ -3571,10 +3576,14 @@ If the OBJ's `key' is currently unreachable, then apply the face
              (propertize "[" 'face 'transient-inactive-value)
              (mapconcat
               (lambda (choice)
-                (propertize choice 'face
-                            (if (equal (format argument-format choice) value)
-                                'transient-value
-                              'transient-inactive-value)))
+                (propertize
+                 (if (consp choice) (cdr choice) choice)
+                 'face
+                 (if (equal (format argument-format
+                                    (if (consp choice) (car choice) choice))
+                            value)
+                     'transient-value
+                   'transient-inactive-value)))
               choices
               (propertize "|" 'face 'transient-inactive-value))
              (propertize "]" 'face 'transient-inactive-value)))))


### PR DESCRIPTION
This small patch allows choices in `transient-switches` to be each a cons so that options that accept non-descriptive values can still be displayed with descriptive text.

I created this as a pull-request draft since, if this is of interest, a similar change to `transient-option` would also be needed for consistency.

Example usage:
```lisp
(defun snowcone-eater (args)
  (interactive (list (transient-args 'transient-toys-snowcone-eater)))
  (message "%S" args))

(transient-define-argument transient-toys--snowcone-flavor ()
  :description "Flavor of snowcone"
  :class 'transient-switches
  :key "s"
  :argument-format "--snowcone=%s"
  :argument-regexp "\\(--snowcone=\\(2\\|3\\|4\\|8\\)\\)"
  :choices '("none" 
             (2 . "grape")
             (3 . "orange")
             (4 . "cherry")
             (9 . "lime")))

(transient-define-prefix transient-toys-snowcone-eater ()
  "Eat a flavored snowcone!"
  :value '("--orange-snowcone")

  ["Arguments"
   (transient-toys--snowcone-flavor)
   ("C-c C-s" "Show options"
   snowcone-eater
   :transient t)])

(transient-toys-snowcone-eater)
```
