### PR TITLE
Lisp variable can fall back to prompt if apt

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -4124,7 +4124,10 @@ we stop there."
               'face 'transient-value))
 
 (cl-defmethod transient-prompt ((obj transient-lisp-variable))
-  (format "Set %s: " (oref obj variable)))
+  (if (and (slot-boundp obj 'prompt)
+           (oref obj prompt))
+      (cl-call-next-method obj)
+    (format "Set %s: " (oref obj variable))))
 
 (defun transient-lisp-variable--reader (prompt initial-input _history)
   (read--expression prompt initial-input))


### PR DESCRIPTION
The lisp variable only needs this override behavior if the user provides no prompt or nil prompt.

This change is testable in the following example:

```elisp
     (defvar ts--position '(0 0) "A transient prefix location")

       (transient-define-infix ts--pos-infix ()
         "A location, key, or command symbol"
         :class 'transient-lisp-variable
         :transient t
         ;; comment this line to see unbound case
         ;; lambda and nil also behave correctly
         :prompt "An expression such as (0 0), \"p\", nil, 'ts--msg-pos: "
         :variable 'ts--position)

       (transient-define-suffix ts--msg-pos ()
         "Message the element at location"
         :transient 'transient--do-call
         (interactive)
         ;; lisp variables are not sent in the usual (transient-args) list.
         ;; Just read `ts--position' directly.
         (let ((suffix (transient-get-suffix transient-current-command ts--position)))
           (message "%s" (oref suffix description))))

       (transient-define-prefix ts-lisp-variable ()
         "A prefix that updates and uses a lisp variable."
         ["Location Printing"
          [("p" "position" ts--pos-infix)]
          [("m" "message" ts--msg-pos)]])

       ;; (ts-lisp-variable)
```

Signed-off-by: Psionik K <73710933+psionic-k@users.noreply.github.com>

