### PR TITLE
Broaden allow empty

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2890,6 +2890,7 @@ it\", in which case it is pointless to preserve history.)"
              (history (if initial-input
                           (cons 'transient--history 1)
                         'transient--history))
+             (original-value value)
              (value
               (cond
                (reader (funcall reader prompt initial-input history))
@@ -2900,7 +2901,7 @@ it\", in which case it is pointless to preserve history.)"
                 (completing-read prompt choices nil t initial-input history))
                (t (read-string prompt initial-input history)))))
         (cond ((and (equal value "") (not allow-empty))
-               (setq value nil))
+               (setq value original-value))
               ((and (equal value "\"\"") allow-empty)
                (setq value "")))
         (when value

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2901,6 +2901,7 @@ it\", in which case it is pointless to preserve history.)"
                 (completing-read prompt choices nil t initial-input history))
                (t (read-string prompt initial-input history)))))
         (cond ((and (equal value "") (not allow-empty))
+               (message "Empty input not allowed.")
                (setq value original-value))
               ((and (equal value "\"\"") allow-empty)
                (setq value "")))


### PR DESCRIPTION
Consider the following prefix:

```elisp
(transient-define-prefix ts-basic-infixes ()
  "Prefix that just shows off many typical infix types."
  ["Infixes"
   ("-n" "never empty" "--non-null=" :always-read t  :allow-empty nil
    ;; this is a bit verbose way to set an initial value from the example
    :init-value (lambda (obj) (oset obj value "better-than-nothing"))))
```

When given an empty input, the infix should reject the input and tell the user why.

The empty string response remains valid.  I suppose this is an acceptable workaround if the users knows an empty string is in fact valid.