### PR TITLE
Fix bug using :incompatible using suffixes before infixes

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -3044,10 +3044,12 @@ prompt."
         (progn
           (cl-call-next-method obj value)
           (dolist (arg incomp)
-            (when-let ((obj (cl-find-if (lambda (obj)
-                                          (and (slot-boundp obj 'argument)
-                                               (equal (oref obj argument) arg)))
-                                        transient--suffixes)))
+            (when-let ((obj (cl-find-if
+                             (lambda (obj)
+                               (and (slot-exists-p obj 'argument)
+                                    (slot-boundp obj 'argument)
+                                    (equal (oref obj argument) arg)))
+                             transient--suffixes)))
               (let ((transient--unset-incompatible nil))
                 (transient-infix-set obj nil)))))
       (cl-call-next-method obj value))))


### PR DESCRIPTION
Fix #247. When using :incompatible with another option that has defined suffix no argument, if that option comes before the incompatible options, you get an (invalid-slot-name "#<transient-suffix transient-suffix-53012386>" argument) error.

This happens because `transient-infix-set` calls `(slot-boundp obj 'argument)`, and `argument` will not be bound for suffixes with no argument, signalling the error.

To fix, add a `(slot-exist-p obj 'argument)` guard first, to avoid tripping the signal.

Here is a test transient that works with this PR but does not work with current `main`:

```emacs-lisp
(require 'transient)

(transient-define-suffix simple-suffix ()
  (interactive)
  (message "args %S" (transient-args transient-current-command)))

(transient-define-prefix incompatible-bug ()
  :incompatible '(("a=" "b="))
  [""
   ("x" "exit" simple-suffix)
   ("a" "a" "a=")
   ("b" "b" "b=")])
```