### PR TITLE
manual: Mark up nil as ~nil~

### DIFF
--- a/docs/transient.org
+++ b/docs/transient.org
@@ -1848,7 +1848,7 @@ They are defined here anyway to allow sharing certain methods.
   ~transient-args~, e.g., ~("--other" "--o=1" "--o=2" ("--" "f1" "f2"))~.
 
 - ~always-read~ For options, whether to read a value on every invocation.
-  If this is nil, then options that have a value are simply unset and
+  If this is ~nil~, then options that have a value are simply unset and
   have to be invoked a second time to set a new value.
 
 - ~allow-empty~ For options, whether the empty string is a valid value.

--- a/docs/transient.texi
+++ b/docs/transient.texi
@@ -2141,7 +2141,7 @@ default value of a prefix using the same format as returned by
 
 @item
 @code{always-read} For options, whether to read a value on every invocation.
-If this is nil, then options that have a value are simply unset and
+If this is @code{nil}, then options that have a value are simply unset and
 have to be invoked a second time to set a new value.
 
 @item


### PR DESCRIPTION
I spotted the missing `@code` markup in the copy of `doc/misc/transient.texi` in `emacs.git`.
Is this the correct place to add it?
I regenerated `transient.texi` in `transient.git` using the command:
```
$ make LOAD_PATH="-L ${HOME}/.emacs.d/elpa/compat-29.1.4.1.0.20230524.90557" texi
```
Thanks.