### PR TITLE
Revert "transient-{set,save,reset}: Stay transient"

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -1625,9 +1625,9 @@ of the corresponding object."
   "<transient-show>"              #'transient--do-stay
   "<transient-update>"            #'transient--do-stay
   "<transient-toggle-common>"     #'transient--do-stay
-  "<transient-set>"               #'transient--do-stay
-  "<transient-save>"              #'transient--do-stay
-  "<transient-reset>"             #'transient--do-stay
+  "<transient-set>"               #'transient--do-call
+  "<transient-save>"              #'transient--do-call
+  "<transient-reset>"             #'transient--do-call
   "<describe-key-briefly>"        #'transient--do-stay
   "<describe-key>"                #'transient--do-stay
   "<transient-scroll-up>"         #'transient--do-stay


### PR DESCRIPTION
## Commit message

This reverts commit 361d8ac61bf75e027173f84a1013d87364a4ec3e.

When transient--do-stay is used, transient does not export variables. This causes it to save the command without any of its arguments present.

For example, say one wants to only pass "--decorate" to magit-log. One would open the log menu and set the "--decorate" option, and then save it via C-x C-s. With do-call, the .emacs.d/.local/etc/transient/values file looks like:

    $ cat values
    ((magit-log:magit-log-mode "--decorate"))

With do-stay, it looks like:

    $ cat values
    ((magit-log:magit-log-mode))

The result of this bug is that whenever you save any set of options, the next time around /all/ of your options will be unselected.

## Notes (not in commit message)

I do not know transient so well so I can't pinpoint exactly _why_ this happens. `transient_save` still passes `transient--prefix` to `transient-save-value` which is the same in both cases but for some reason, the one will `do-call` ends up writing the correct values.

I also do not know why you changed `do-call` to `do-stay` in the first place. So reverting it is the only sensible thing I can see. Your commit message does not say much. Perhaps it is a hint to write better commit messages ;-)

Output of `M-x magit-version`:

```
Magit 4881835 [>= 3.3.0.50-git], Transient 0.4.3, Git 2.40.1, Emacs 30.0.50, gnu/linux
```