### PR TITLE
Declare version with "Version" rather than "Package-Version"

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/magit/transient
 ;; Keywords: extensions
 
-;; Package-Version: 0.4.3
+;; Version: 0.4.3
 ;; Package-Requires: ((emacs "26.1") (compat "29.1.4.1") (seq "2.24"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
Hello,

I assume this is the place to report this, rather than the emacs mailing list.

Since `transient` is now a builtin package of emacs, the variable `package--builtins` in the `finder-inf` library stores its name, version and a short description : 

```elisp
...
(tramp . [(2 6 0 29 1) nil "Transparent Remote Access, Multiple Protocol"])
(transient . [nil nil "Transient commands"])
(tree-widget . [nil nil "Tree widget"])
...
```

The version is not reported properly since the header keyword used to declare the version in `transient` is `Package-Version`, which is `package`-specific, rather than `Version`, which is the standard way (`finder`, the library that sets `package--builtins`, looks for this header only).

`package` looks for both `Package-Version` and `Version` headers, so this should not break anything.

Best,

Aymeric Agon-Rambosson
