### PR TITLE
Update transient.el.  Don't intern transient symbols

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -1133,7 +1133,7 @@ this case, because the `man-page' slot was not set in this case."
        ((and (commandp car)
              (not (stringp car)))
         (let ((cmd pop)
-              (sym (intern
+              (sym (make-symbol
                     (format "transient:%s:%s"
                             prefix
                             (let ((desc (plist-get args :description)))
@@ -1162,7 +1162,7 @@ this case, because the `man-page' slot was not set in this case."
              (when-let ((shortarg (transient--derive-shortarg arg)))
                (setq args (plist-put args :shortarg shortarg)))
              (setq args (plist-put args :argument arg))))
-          (setq sym (intern (format "transient:%s:%s" prefix arg)))
+          (setq sym (make-symbol (format "transient:%s:%s" prefix arg)))
           (setq args (plist-put
                       args :command
                       `(prog1 ',sym


### PR DESCRIPTION
See Emacs bug#68568

> Please use a dedicated feature branch for your feature request, instead of asking us to merge "your-fork/master" into the 
> "origin/master".  The use of dedicated branches makes it much more convenient to deal with pull-requests, especially when > using Magit to do so.

I don't use Magit.  This is a just a fix for a very annoying bug where completion gets completely broken just because I use a package that uses transient.

> If you were about to open a pull-request asking us to merge your version of "master", then see [1] for instructions on how to quickly fix that and some information on why we ask you to do so.

YOu can push to my master of magit any time.  The patch is trivial.