### PR TITLE
Revert "transient--post-command: Clear transient-current-* variables here"

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2553,11 +2553,7 @@ value.  Otherwise return CHILDREN as is."
                  (transient--pop-keymap 'transient--redisplay-map)
                  (setq transient--redisplay-map new)
                  (transient--push-keymap 'transient--redisplay-map))
-               (transient--redisplay))))))
-  (transient--debug 'clear-current)
-  (setq transient-current-prefix nil)
-  (setq transient-current-command nil)
-  (setq transient-current-suffixes nil))
+               (transient--redisplay)))))))
 
 (defun transient--post-exit (&optional command)
   (transient--debug 'post-exit)
@@ -2580,6 +2576,9 @@ value.  Otherwise return CHILDREN as is."
     (remove-hook 'pre-command-hook  #'transient--pre-command)
     (remove-hook 'post-command-hook #'transient--post-command)
     (advice-remove 'recursive-edit #'transient--recursive-edit))
+  (setq transient-current-prefix nil)
+  (setq transient-current-command nil)
+  (setq transient-current-suffixes nil)
   (let ((resume (and transient--stack
                      (not (memq transient--exitp '(replace suspend))))))
     (unless (or resume (eq transient--exitp 'replace))


### PR DESCRIPTION
This reverts commit 0e0ece32362bb5eed430328583018a35f44d3c7d which broke magit.  Specifically, rebase options were not taking effect:

    M-x magit RET
    r - i e RET

behaved the same as:

    M-x magit RET
    r e RET

FYI @tarsius 