### PR TITLE
transient-prefix: Add display-action slot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,10 @@
 - ~transient-setup-buffer-hook~ is now run later to allow overriding
   more default settings.
 
+- The new prefix slots ~display-action~ and ~mode-line-format~, can be
+  used to override ~transient-display-buffer-action~ and
+  ~transient-mode-line-format~ for individual prefix menus.  #332
+
 Bug fixes:
 
 - Fixes some menu navigation edge-cases.

--- a/docs/transient.org
+++ b/docs/transient.org
@@ -522,6 +522,9 @@ Also see [[* Common Suffix Commands]].
   If you change the value of this option, then you might also
   want to change the value of ~transient-mode-line-format~.
 
+  This user option may be overridden if ~:display-action~ is passed
+  when creating a new prefix with ~transient-define-prefix~.
+
 *** Accessibility Options
 :PROPERTIES:
 :UNNUMBERED: notoc
@@ -1951,6 +1954,9 @@ functions use ~describe-function~.
   against a specific value, as returned by ~transient-infix-value~,
   for example, ~--option=one~.
 
+- ~display-action~ determines how this prefix is displayed, overriding
+  ~transient-display-buffer-action~.  It should have the same type.
+
 - ~scope~ For some transients it might be necessary to have a sort of
   secondary value, called a “scope”.  See ~transient-define-prefix~.
 
@@ -2170,7 +2176,9 @@ See [[*Enabling and Disabling Suffixes]].
 :UNNUMBERED: notoc
 :END:
 
-Yes, see ~transient-display-buffer-action~ in [[*Configuration]].
+Yes, see ~transient-display-buffer-action~ in [[*Configuration]].  You can
+also control how the popup buffer is displayed on a case-by-case basis
+by passing ~:display-action~ to ~transient-define-prefix~.
 
 ** How can I copy text from the popup buffer?
 :PROPERTIES:

--- a/docs/transient.org
+++ b/docs/transient.org
@@ -563,6 +563,9 @@ Also see [[* Common Suffix Commands]].
   ~transient-key-exit~ (if allowed and they exit the transient) is
   used to draw the line.
 
+  This user option may be overridden if ~:mode-line-format~ is passed
+  when creating a new prefix with ~transient-define-prefix~.
+
   Otherwise this can be any mode-line format.  See [[info:elisp#Mode
   Line Format]], for details.
 
@@ -1956,6 +1959,9 @@ functions use ~describe-function~.
 
 - ~display-action~ determines how this prefix is displayed, overriding
   ~transient-display-buffer-action~.  It should have the same type.
+
+- ~mode-line-format~ is this prefix's mode line format, overriding
+  ~transient-mode-line-format~.  It should have the same type.
 
 - ~scope~ For some transients it might be necessary to have a sort of
   secondary value, called a “scope”.  See ~transient-define-prefix~.

--- a/docs/transient.texi
+++ b/docs/transient.texi
@@ -684,6 +684,9 @@ then that unfortunately changes which buffer is current.
 
 If you change the value of this option, then you might also
 want to change the value of @code{transient-mode-line-format}.
+
+This user option may be overridden if @code{:display-action} is passed
+when creating a new prefix with @code{transient-define-prefix}.
 @end defopt
 
 @anchor{Accessibility Options}
@@ -2215,6 +2218,10 @@ against a specific value, as returned by @code{transient-infix-value},
 for example, @code{--option=one}.
 
 @item
+@code{display-action} determines how this prefix is displayed, overriding
+@code{transient-display-buffer-action}.  It should have the same type.
+
+@item
 @code{scope} For some transients it might be necessary to have a sort of
 secondary value, called a ``scope''.  See @code{transient-define-prefix}.
 @end itemize
@@ -2489,7 +2496,9 @@ See @ref{Enabling and Disabling Suffixes}.
 @anchor{Can I control how the popup buffer is displayed?}
 @appendixsec Can I control how the popup buffer is displayed?
 
-Yes, see @code{transient-display-buffer-action} in @ref{Configuration}.
+Yes, see @code{transient-display-buffer-action} in @ref{Configuration}.  You can
+also control how the popup buffer is displayed on a case-by-case basis
+by passing @code{:display-action} to @code{transient-define-prefix}.
 
 @anchor{How can I copy text from the popup buffer?}
 @appendixsec How can I copy text from the popup buffer?

--- a/docs/transient.texi
+++ b/docs/transient.texi
@@ -722,6 +722,9 @@ color of @code{transient-key-noop} (if non-suffixes are disallowed),
 @code{transient-key-exit} (if allowed and they exit the transient) is
 used to draw the line.
 
+This user option may be overridden if @code{:mode-line-format} is passed
+when creating a new prefix with @code{transient-define-prefix}.
+
 Otherwise this can be any mode-line format.  See @ref{Mode Line Format,,,elisp,}, for details.
 @end defopt
 
@@ -2220,6 +2223,10 @@ for example, @code{--option=one}.
 @item
 @code{display-action} determines how this prefix is displayed, overriding
 @code{transient-display-buffer-action}.  It should have the same type.
+
+@item
+@code{mode-line-format} is this prefix's mode line format, overriding
+@code{transient-mode-line-format}.  It should have the same type.
 
 @item
 @code{scope} For some transients it might be necessary to have a sort of

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -723,6 +723,7 @@ If `transient-save-history' is nil, then do nothing."
    (environment          :initarg :environment          :initform nil)
    (incompatible         :initarg :incompatible         :initform nil)
    (suffix-description   :initarg :suffix-description)
+   (display-action       :initarg :display-action       :initform nil)
    (variable-pitch       :initarg :variable-pitch       :initform nil)
    (column-widths        :initarg :column-widths        :initform nil)
    (unwind-suffix        :documentation "Internal use." :initform nil))
@@ -3913,12 +3914,9 @@ have a history of their own.")
       (when-let ((line (transient--separator-line)))
         (insert line)))
     (unless (window-live-p transient--window)
-      (when (eq (car transient-display-buffer-action)
-                'display-buffer-full-frame)
-        (user-error "Invalid value for `transient-display-buffer-action'"))
       (setq transient--window
             (display-buffer transient--buffer
-                            transient-display-buffer-action)))
+                            (transient--display-action))))
     (when (window-live-p transient--window)
       (with-selected-window transient--window
         (set-window-parameter nil 'prev--no-other-window
@@ -3928,6 +3926,13 @@ have a history of their own.")
         (when transient-enable-popup-navigation
           (transient--goto-button focus))
         (transient--fit-window-to-buffer transient--window)))))
+
+(defun transient--display-action ()
+  (let ((action (or (oref transient--prefix display-action)
+                    transient-display-buffer-action)))
+    (when (eq (car action) 'display-buffer-full-frame)
+      (user-error "Invalid value for `transient-display-buffer-action'"))
+    action))
 
 (defun transient--fit-window-to-buffer (window)
   (let ((window-resize-pixelwise t)

--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -724,6 +724,7 @@ If `transient-save-history' is nil, then do nothing."
    (incompatible         :initarg :incompatible         :initform nil)
    (suffix-description   :initarg :suffix-description)
    (display-action       :initarg :display-action       :initform nil)
+   (mode-line-format     :initarg :mode-line-format)
    (variable-pitch       :initarg :variable-pitch       :initform nil)
    (column-widths        :initarg :column-widths        :initform nil)
    (unwind-suffix        :documentation "Internal use." :initform nil))
@@ -3896,10 +3897,8 @@ have a history of their own.")
         (setq tab-line-format nil))
       (setq header-line-format nil)
       (setq mode-line-format
-            (if (or (natnump transient-mode-line-format)
-                    (eq transient-mode-line-format 'line))
-                nil
-              transient-mode-line-format))
+            (let ((format (transient--mode-line-format)))
+              (if (or (natnump format) (eq format 'line)) nil format)))
       (setq mode-line-buffer-identification
             (symbol-name (oref transient--prefix command)))
       (if transient-enable-popup-navigation
@@ -3947,11 +3946,16 @@ have a history of their own.")
                               (window-body-width window t)
                               (window-body-height window t))))
 
+(defun transient--mode-line-format ()
+  (if (slot-boundp transient--prefix 'mode-line-format)
+      (oref transient--prefix mode-line-format)
+    transient-mode-line-format))
+
 (defun transient--separator-line ()
-  (and-let* ((height (cond ((not window-system) nil)
-                           ((natnump transient-mode-line-format)
-                            transient-mode-line-format)
-                           ((eq transient-mode-line-format 'line) 1)))
+  (and-let* ((format (transient--mode-line-format))
+             (height (cond ((not window-system) nil)
+                           ((natnump format) format)
+                           ((eq format 'line) 1)))
              (face `(,@(and (>= emacs-major-version 27) '(:extend t))
                      :background
                      ,(or (face-foreground (transient--key-face nil 'non-suffix)


### PR DESCRIPTION
This change lets each transient-prefix display according to its own display-buffer-action.  Resolves this discussion:

https://github.com/magit/transient/discussions/303

I have not thoroughly tested this code, but it seems to work.

If you think this kind of change is appropriate, I'll fixup this commit with an update to the manual and force push.

Thank you!!