### PR TITLE
handle non-aborting unwinds from recursive-edit

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -2960,13 +2960,14 @@ value.  Otherwise return CHILDREN as is.")
   (if (not transient--prefix)
       (funcall fn)
     (transient--suspend-override (bound-and-true-p edebug-active))
-    (funcall fn) ; Already unwind protected.
-    (cond ((memq this-command '(top-level abort-recursive-edit))
-           (setq transient--exitp t)
-           (transient--post-exit this-command)
-           (transient--delete-window))
-          (transient--prefix
-           (transient--resume-override)))))
+    (unwind-protect
+        (funcall fn)
+      (cond ((memq this-command '(top-level abort-recursive-edit))
+             (setq transient--exitp t)
+             (transient--post-exit this-command)
+             (transient--delete-window))
+            (transient--prefix
+             (transient--resume-override))))))
 
 (defmacro transient--with-suspended-override (&rest body)
   (let ((depth (make-symbol "depth"))


### PR DESCRIPTION
The function `recursive-edit` may unwind to its caller if any of the following forms is evaluated during the recursive edit:
- `(abort-recursive-edit)` causing recursive-edit to `quit`
- `(throw 'exit t)`, causing recursive-edit to `quit`
- `(throw 'exit STRING)`, causing recursive-edit to `(error STRING)`

The advice `transient--recursive-edit` behaves correctly in all of the above cases, except in the 3rd case if the error signal is caught after `transient--recursive-edit` unwinds and before the whole transient unwinds. In this case, the transient is left in a poor state. See #425 for more detail on reproducing this.

Adding an unwind-protect to the advice resolves this, but I am unsure if any of the contents of the `cond` ought to change. Specifically, the first arm of the `cond` appears to be trying to pre-empt the unwinding and tidy up, but prior to this PR, this arm does not run in an unwind anyway, and transients seem to handle unwinding from recursive-edit just fine. However, I am not confident to remove this - I do not know if there are any edge-cases that this code was added to handle.

Fixes #425 