### PR TITLE
transient--describe-function: handle describe-function overrides

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -5314,7 +5314,8 @@ Select the help window, and make the help buffer current and return it."
           (cons (lambda () (setq buffer (current-buffer)))
                 temp-buffer-window-setup-hook)))
     (describe-function fn)
-    (set-buffer buffer)))
+    (when buffer
+      (set-buffer buffer))))
 
 (defun transient--show-manual (manual)
   (info manual))


### PR DESCRIPTION
## Problem

`transient--describe-function` captures the help buffer via `temp-buffer-window-setup-hook`. This works with the built-in `describe-function`, which displays its output via `with-help-window` and therefore triggers the hook.

However, a common pattern in the Emacs community is to override `describe-function` with packages like [helpful](https://github.com/Wilfred/helpful):

```elisp
(advice-add 'describe-function :override #'helpful-function)
```

This is recommended by [Doom Emacs](https://github.com/doomemacs/doomemacs), [Spacemacs](https://github.com/syl20bnr/spacemacs), and countless dotfiles. `helpful-function` creates and displays its buffer via `pop-to-buffer` rather than `with-help-window`, so `temp-buffer-window-setup-hook` never fires, `buffer` stays nil, and `(set-buffer nil)` signals `(wrong-type-argument stringp nil)`.

This means pressing `?` followed by a suffix key in any transient menu errors out for anyone using this pattern.

## Fix

```diff
     (describe-function fn)
-    (set-buffer buffer))
+    (when buffer (set-buffer buffer)))
```

When the hook fires (standard `describe-function`), behavior is unchanged. When it doesn't (`helpful` or any other override that bypasses `with-help-window`), we skip the `set-buffer` call entirely — the override's `pop-to-buffer` already selected the correct window and set the current buffer, so no further action is needed.

## Context

This is in the spirit of the robustness improvements in #208 and #213, which led to commit 732ec975 rewriting `transient--describe-function` because it was "too fragile" — it assumed `(help-buffer)` would return the correct buffer, which broke when packages like [epithet](https://github.com/oantolin/epithet) renamed help buffers. The current implementation replaced that assumption with `temp-buffer-window-setup-hook`, but this hook has the same fragility when `describe-function` itself is replaced with something that doesn't use `with-help-window`.