### PR TITLE
fix: regex in transient-init-value to include newlines

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -3891,7 +3891,7 @@ Call `transient-default-value' but because that is a noop for
               (case-fold-search nil)
               (regexp (if (slot-exists-p obj 'argument-regexp)
                           (oref obj argument-regexp)
-                        (format "\\`%s\\(.*\\)" (oref obj argument)))))
+                        (format "\\`%s\\([^z-a]*\\)\\'" (oref obj argument)))))
           (if (memq multi-value '(t rest))
               (cdr (assoc argument value))
             (let ((match (lambda (v)


### PR DESCRIPTION
Allow `transient-init-value` to respect multiline string values, rather than truncating them to the first line.

`.*` does not match multiline strings because the `.` pattern matches any character besides a line terminator. Emacs regex syntax uses the `[^z-a]` pattern to match any character including line terminators.

Fixes #432