### PR TITLE
transient--suspend-text-conversion-style: Guard Emacs 30 variable

### DIFF
--- a/lisp/transient.el
+++ b/lisp/transient.el
@@ -5629,7 +5629,7 @@ search instead."
             lisp-imenu-generic-expression :test #'equal)
 
 (defun transient--suspend-text-conversion-style ()
-  (when (and text-conversion-style
+  (when (and (bound-and-true-p text-conversion-style)
              (bound-and-true-p overriding-text-conversion-style))
     (letrec ((suspended overriding-text-conversion-style)
              (fn (lambda ()


### PR DESCRIPTION
Opening any Transient menu on Emacs 29 can fail before the menu appears,
because `text-conversion-style` is not bound there.  Treat the missing
variable the same as a nil value, just as we already do for
`overriding-text-conversion-style`.
